### PR TITLE
fix(ui): 修复 SiteIcon 在 Electron 环境中的图标路径问题

### DIFF
--- a/packages/components/mind/tsconfig.json
+++ b/packages/components/mind/tsconfig.json
@@ -25,5 +25,6 @@
     "useDefineForClassFields": true
   },
   "include": ["src"],
+  "exclude": ["node_modules", "dist", "*.md"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }

--- a/packages/components/ui/src/SiteIcon.tsx
+++ b/packages/components/ui/src/SiteIcon.tsx
@@ -14,6 +14,11 @@ export default function SiteIcon({
   height?: number;
   className?: string;
 } & React.SVGAttributes<SVGSVGElement>) {
+  // 在 Electron 环境中使用相对路径，在 Web 环境中使用绝对路径
+  const iconPath = typeof window !== 'undefined' && (window as any).electronAPI 
+    ? './icons.svg' 
+    : '/icons.svg';
+    
   return (
     <svg
       width={width}
@@ -22,7 +27,7 @@ export default function SiteIcon({
       onClick={onClick}
       style={{ ...style, fill: 'currentColor' }}
     >
-      <use href={`/icons.svg#${id}`} />
+      <use href={`${iconPath}#${id}`} />
     </svg>
   );
 }


### PR DESCRIPTION
在 Electron 环境中使用相对路径 './icons.svg'，在 Web 环境中使用绝对路径 '/icons.svg'